### PR TITLE
Enforcing `VERIFY_PEER` on the client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,2 @@
 source 'https://rubygems.org'
-
-gem "rspec"
-gem "insist"
-gem "stud"
-gem "fpm"
-gem "pleaserun"
-
-gem "jruby-openssl", :platform => :jruby
+gemspec

--- a/jls-lumberjack.gemspec
+++ b/jls-lumberjack.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = "0.0.23"
 
-  gem.add_development_dependency "flores", "0.0.5"
+  gem.add_development_dependency "flores", "~>0.0.6"
   gem.add_development_dependency "rspec"
   gem.add_development_dependency "stud"
 end

--- a/jls-lumberjack.gemspec
+++ b/jls-lumberjack.gemspec
@@ -5,17 +5,14 @@ Gem::Specification.new do |gem|
   gem.summary       = gem.description
   gem.homepage      = "https://github.com/jordansissel/lumberjack"
 
-  gem.files = %w{
-    lib/lumberjack/server.rb
-    lib/lumberjack/client.rb
-  }
-    #lib/lumberjack/server2.rb
+  gem.files = Dir.glob("lib/**/*.rb")
 
-  gem.test_files    = []
+  gem.test_files    = Dir.glob("spec/**/*.rb")
   gem.name          = "jls-lumberjack"
   gem.require_paths = ["lib"]
-  gem.version       = "0.0.22"
+  gem.version       = "0.0.23"
 
-  # This isn't used yet because the new protocol isn't ready
-  #gem.add_runtime_dependency "ffi-rzmq", "~> 1.0.0"
+  gem.add_development_dependency "flores", "0.0.5"
+  gem.add_development_dependency "rspec"
+  gem.add_development_dependency "stud"
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
-require "lib/lumberjack/client"
-require "lib/lumberjack/server"
+require "lumberjack/client"
+require "lumberjack/server"
 require "stud/temporary"
 require "flores/pki"
 require "fileutils"

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -8,29 +8,15 @@ require "thread"
 require "spec_helper"
 
 describe "A client" do
-  let(:port) { Flores::Random.integer(1024..65335) }
-  let(:csr) { Flores::PKI::CertificateSigningRequest.new }
-  let(:key_bits) { 1024 }
-  let(:key) { OpenSSL::PKey::RSA.generate(key_bits, 65537) }
-  let(:certificate_duration) { Flores::Random.number(1..86400) }
-  let(:certificate_subject) { "CN=server.example.com" }
-  let(:certificate) { csr.create }
+  let(:certificate) { Flores::PKI.generate }
   let(:certificate_file_crt) { "certificate.crt" }
   let(:certificate_file_key) { "certificate.key" }
+  let(:port) { Flores::Random.integer(1024..65335) }
   let(:host) { "127.0.0.1" }
-  let(:queue) { Queue.new }
-  let(:payload) { {"line" => "hello world" } }
 
   before do
-    csr.subject = certificate_subject
-    csr.public_key = key.public_key
-    csr.start_time = Time.now
-    csr.expire_time = csr.start_time + certificate_duration
-    csr.signing_key = key
-    csr.want_signature_ability = true
-
-    expect(File).to receive(:read).twice.with(certificate_file_crt) { certificate.to_s }
-    expect(File).to receive(:read).with(certificate_file_key) { key.to_s }
+    expect(File).to receive(:read).at_least(1).with(certificate_file_crt) { certificate.first.to_s }
+    expect(File).to receive(:read).at_least(1).with(certificate_file_key) { certificate.last.to_s }
     
     server = Lumberjack::Server.new(:port => port,
                                     :address => host,
@@ -38,20 +24,38 @@ describe "A client" do
                                     :ssl_key => certificate_file_key)
 
     Thread.new do
-      server.run { |data| queue.push(data) }
+      server.run { |data| }
     end
   end
 
-  it "should require a certificate" do
-    expect { 
-      client = Lumberjack::Client.new(:port => port, 
-                             :host => host,
-                             :addresses => host,
-                             :ssl_certificate => certificate_file_crt)
+  context "with a valid certificate" do
+    it "successfully connect to the server" do
+      expect { 
+        Lumberjack::Client.new(:port => port, 
+                               :host => host,
+                               :addresses => host,
+                               :ssl_certificate => certificate_file_crt)
 
-      client.write(payload)
-    }.not_to raise_error
+      }.not_to raise_error
+    end
+  end
 
-    expect(queue.pop).to eq(payload)
+  context "with an invalid certificate" do
+    let(:invalid_certificate) { Flores::PKI.generate }
+    let(:invalid_certificate_file) { "invalid.crt" }
+
+    before do
+      expect(File).to receive(:read).with(invalid_certificate_file) { invalid_certificate.first.to_s }
+    end
+
+    it "should refuse to connect" do
+      expect { 
+        Lumberjack::Client.new(:port => port, 
+                               :host => host,
+                               :addresses => host,
+                               :ssl_certificate => invalid_certificate_file)
+
+      }.to raise_error(OpenSSL::SSL::SSLError, /certificate verify failed/)
+    end
   end
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -1,0 +1,57 @@
+# encoding: utf-8
+require "lib/lumberjack/client"
+require "lib/lumberjack/server"
+require "stud/temporary"
+require "flores/pki"
+require "fileutils"
+require "thread"
+require "spec_helper"
+
+describe "A client" do
+  let(:port) { Flores::Random.integer(1024..65335) }
+  let(:csr) { Flores::PKI::CertificateSigningRequest.new }
+  let(:key_bits) { 1024 }
+  let(:key) { OpenSSL::PKey::RSA.generate(key_bits, 65537) }
+  let(:certificate_duration) { Flores::Random.number(1..86400) }
+  let(:certificate_subject) { "CN=server.example.com" }
+  let(:certificate) { csr.create }
+  let(:certificate_file_crt) { "certificate.crt" }
+  let(:certificate_file_key) { "certificate.key" }
+  let(:host) { "127.0.0.1" }
+  let(:queue) { Queue.new }
+  let(:payload) { {"line" => "hello world" } }
+
+  before do
+    csr.subject = certificate_subject
+    csr.public_key = key.public_key
+    csr.start_time = Time.now
+    csr.expire_time = csr.start_time + certificate_duration
+    csr.signing_key = key
+    csr.want_signature_ability = true
+
+    expect(File).to receive(:read).twice.with(certificate_file_crt) { certificate.to_s }
+    expect(File).to receive(:read).with(certificate_file_key) { key.to_s }
+    
+    server = Lumberjack::Server.new(:port => port,
+                                    :address => host,
+                                    :ssl_certificate => certificate_file_crt,
+                                    :ssl_key => certificate_file_key)
+
+    Thread.new do
+      server.run { |data| queue.push(data) }
+    end
+  end
+
+  it "should require a certificate" do
+    expect { 
+      client = Lumberjack::Client.new(:port => port, 
+                             :host => host,
+                             :addresses => host,
+                             :ssl_certificate => certificate_file_crt)
+
+      client.write(payload)
+    }.not_to raise_error
+
+    expect(queue.pop).to eq(payload)
+  end
+end


### PR DESCRIPTION
The ruby client did not enforce the validation of the certificate,
opening possible man in the middle attacks on the client. This PR make sure that
the `verify_mode` is set to `VERIFY_PEER` and add the certificate to the store
for this specific connection. An integration test was added to validate
this change.

This change makes the ruby client handling of connection closer to the
`logstash-forwarder` behavior, which does the verify peer per default.

Fixes #4