### PR TITLE
Allow to close a connection and a server

### DIFF
--- a/jls-lumberjack.gemspec
+++ b/jls-lumberjack.gemspec
@@ -10,10 +10,13 @@ Gem::Specification.new do |gem|
   gem.test_files    = Dir.glob("spec/**/*.rb")
   gem.name          = "jls-lumberjack"
   gem.require_paths = ["lib"]
-  gem.version       = "0.0.24"
+  gem.version       = "0.0.25"
+
+  gem.add_runtime_dependency "concurrent-ruby"
 
   gem.add_development_dependency "flores", "~>0.0.6"
   gem.add_development_dependency "rspec"
   gem.add_development_dependency "stud"
   gem.add_development_dependency "pry"
+  gem.add_development_dependency "rspec-wait"
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -7,8 +7,6 @@ require "fileutils"
 require "thread"
 require "spec_helper"
 
-Thread.abort_on_exception = true
-
 describe "A client" do
   let(:certificate) { Flores::PKI.generate }
   let(:certificate_file_crt) { "certificate.crt" }
@@ -25,14 +23,14 @@ describe "A client" do
     tcp_server = Lumberjack::Server.new(:port => tcp_port, :address => host, :ssl => false)
 
     ssl_server = Lumberjack::Server.new(:port => port,
-                                    :address => host,
-                                    :ssl_certificate => certificate_file_crt,
-                                    :ssl_key => certificate_file_key)
+                                        :address => host,
+                                        :ssl_certificate => certificate_file_crt,
+                                        :ssl_key => certificate_file_key)
 
     @tcp_server = Thread.new do
       while true
         tcp_server.accept do |socket|
-          con = Lumberjack::Connection.new(socket)
+          con = Lumberjack::Connection.new(socket, tcp_server)
           begin
             con.run { |data| queue << data }
           rescue

--- a/spec/lumberjack/connection_spec.rb
+++ b/spec/lumberjack/connection_spec.rb
@@ -1,0 +1,45 @@
+# encoding: utf-8
+require "lumberjack/server"
+require "spec_helper"
+require "flores/random"
+
+describe "Connnection" do
+  let(:server) { double("server", :closed? => false) }
+  let(:socket) { double("socket", :closed? => false) }
+  let(:connection) { Lumberjack::Connection.new(socket, server) }
+  let(:payload) { {"line" => "foobar" } }
+  let(:start_sequence) { Flores::Random.integer(0..2000) }
+  let(:random_number_of_events) { Flores::Random.integer(2..200) }
+
+  context "when the server is running" do
+    before do
+      expect(socket).to receive(:sysread).at_least(:once).with(Lumberjack::Connection::READ_SIZE).and_return("")
+      allow(socket).to receive(:syswrite).with(anything).and_return(true)
+      allow(socket).to receive(:close)
+
+      expectation = receive(:feed)
+        .with("")
+        .and_yield(:window_size, random_number_of_events)
+
+      random_number_of_events.times { |n| expectation.and_yield(:data, start_sequence + n + 1, payload) }
+
+      expect_any_instance_of(Lumberjack::Parser).to expectation
+    end
+
+    it "should ack the end of a sequence" do
+      expect(socket).to receive(:syswrite).with(["1A", random_number_of_events + start_sequence].pack("A*N"))
+      connection.read_socket
+    end
+  end
+
+  context "when the server stop" do
+    let(:server) { double("server", :closed? => true) }
+    before do
+      expect(socket).to receive(:close).and_return(true)
+    end
+
+    it "stop reading from the socket" do
+      expect { |b| connection.run(&b) }.not_to yield_control
+    end
+  end
+end

--- a/spec/lumberjack/server_spec.rb
+++ b/spec/lumberjack/server_spec.rb
@@ -1,33 +1,42 @@
 # encoding: utf-8
+require "lumberjack/client"
 require "lumberjack/server"
-require "spec_helper"
 require "flores/random"
+require "flores/pki"
+require "spec_helper"
+
+Thread.abort_on_exception = true
 
 describe "Server" do
-  let(:socket) { double("socket") }
-  let(:connection) { Lumberjack::Connection.new(socket) }
-  let(:payload) { {"line" => "foobar" } }
-  let(:start_sequence) { Flores::Random.integer(0..2000) }
-  let(:random_number_of_events) { Flores::Random.integer(2..200) }
+  let(:certificate) { Flores::PKI.generate }
+  let(:certificate_file_crt) { "certificate.crt" }
+  let(:certificate_file_key) { "certificate.key" }
+  let(:port) { Flores::Random.integer(1024..65335) }
+  let(:tcp_port) { port + 1 }
+  let(:host) { "127.0.0.1" }
+  let(:queue) { [] }
 
   before do
-    expect(socket).to receive(:sysread).at_least(:once).with(Lumberjack::Connection::READ_SIZE).and_return("")
-    allow(socket).to receive(:syswrite).with(anything).and_return(true)
-    allow(socket).to receive(:close)
-
-    expectation = receive(:feed)
-      .with("")
-      .and_yield(:window_size, random_number_of_events)
-
-    random_number_of_events.times { |n| expectation.and_yield(:data, start_sequence + n + 1, payload) }
-
-    expect_any_instance_of(Lumberjack::Parser).to expectation
+    expect(File).to receive(:read).at_least(1).with(certificate_file_crt) { certificate.first.to_s }
+    expect(File).to receive(:read).at_least(1).with(certificate_file_key) { certificate.last.to_s }
   end
 
-  describe "Connnection" do
-    it "should ack the end of a sequence" do
-      expect(socket).to receive(:syswrite).with(["1A", random_number_of_events + start_sequence].pack("A*N"))
-      connection.read_socket
+  subject do
+    Lumberjack::Server.new(:port => port,
+                           :address => host,
+                           :ssl_certificate => certificate_file_crt,
+                           :ssl_key => certificate_file_key)
+  end
+
+  it "should not block when closing the server" do
+    thread = Thread.new do
+      subject.run do |event|
+        queue << event
+      end
     end
+
+    sleep(1) while thread.status != "run"
+    subject.close
+    wait_for { thread.status }.to be_falsey
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,8 @@
 # encoding: utf-8
 require 'rspec'
 require 'rspec/mocks'
+require 'rspec/wait'
+
 $: << File.realpath(File.join(File.dirname(__FILE__), "..", "lib"))
 
 RSpec.configure do |config|


### PR DESCRIPTION
When doing the refactor of the inputs plugin to support a clean
shutdown, I saw there was no way to gracefully close a Lumberjack
server. This PR add `#close` method on the server class and the
connection class.